### PR TITLE
Update core.async dependency.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        org.clojure/core.async {:mvn/version "1.3.618"}}
+        org.clojure/core.async {:mvn/version "1.6.673"}}
 
  :aliases {:build {:deps {io.github.seancorfield/build-clj
                           {:git/tag "v0.8.0" :git/sha "9bd8b8a"}}


### PR DESCRIPTION
This also brings in more recent version of tools.analyzer libs updated for Clojure 1.11